### PR TITLE
switch from ff-dt to gecko-dev to retrieve up-to-date devtools

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,8 @@ env:
         - GIT_NAME="travis"
         - GIT_EMAIL="deploy@travis-ci.org"
 script:
-    - npm run travis-render
+    - echo "Cloning gecko-dev can take some time"
+    - travis_wait 30 npm run travis-render
 after_success:
     - npm run travis-publish
 before_install:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # [Firefox Developer Tools Docs](http://devtools-html.github.io/docs) [![Travis tests][travis-image]][travis-url]
 
-This repository contains scripts that download the sources, *render* and publish the docs, which are hosted elsewhere (currently in the `docs/` folder of [this repository](https://github.com/ochameau/ff-dt/)).
+This repository contains scripts that download the sources, *render* and publish the docs, which are hosted elsewhere (currently in the `devtools/docs/` folder of [this repository](https://github.com/mozilla/gecko-dev)).
 
 The automation happens on Travis CI. You can check the [status of the builds](https://travis-ci.org/devtools-html/docs) if you're curious.
 

--- a/config.js
+++ b/config.js
@@ -1,4 +1,4 @@
 module.exports = {
-	address: 'https://github.com/ochameau/ff-dt.git',
-	directory: 'ff-dt'
+	address: 'https://github.com/mozilla/gecko-dev',
+	directory: 'gecko-dev'
 };

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "main": "index.js",
   "scripts": {
     "update": "node update-repo.js",
-    "build": "gitbook build ./ff-dt/docs/ ./output",
-	"travis-render": "npm run update && npm run build && cp ./CNAME ./output",
+    "build": "gitbook build ./gecko-dev/devtools/docs/ ./output",
+    "travis-render": "npm run update && npm run build && cp ./CNAME ./output",
     "travis-publish": "gh-pages-travis"
   },
   "repository": {


### PR DESCRIPTION
Sorry about using a branch here, but I can't fork the repository for some reason? (my fork appears, then 404 ...).

So for now I don't see any other option than cloning gecko-dev. Let me know what you think.