### PR TITLE
Install gitbook plugins before building the doc

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "update": "node update-repo.js",
-    "build": "gitbook build ./gecko-dev/devtools/docs/ ./output",
+    "build": "gitbook install ./gecko-dev/devtools/docs/ && gitbook build ./gecko-dev/devtools/docs/ ./output",
     "travis-render": "npm run update && npm run build && cp ./CNAME ./output",
     "travis-publish": "gh-pages-travis"
   },


### PR DESCRIPTION
In [Bug 1568472](https://bugzilla.mozilla.org/show_bug.cgi?id=1568472) we added a `book.json` file (which is the config file for Gitbook), containing the `hints` plugin that is currently used in the doc (but since it's not installed, building the doc fails).

We add `gitbook install` before building the doc so we install any plugin we might need.